### PR TITLE
Add a sleep operation to wait until the login page is fully rendered

### DIFF
--- a/starterfiles/test/functional/slash_command.test.js
+++ b/starterfiles/test/functional/slash_command.test.js
@@ -25,6 +25,7 @@ describe('Starter Test', () => {
     it('should be titled "Slack | Spec Test Bot | Slack Community" after logging in and opening DMs', async () => {
       // Log in
       await page.goto('https://community.slack.com');
+      await new Promise(function(resolve) { setTimeout(resolve, 1000); }); // wait til the page is fully rendered
       await expect(page).toFill('input[id="email"]', process.env.email, { timeout: TIMEOUT });
       await expect(page).toFill('input[id="password"]', process.env.password, { timeout: TIMEOUT });
       await expect(page).toClick('button[id="signin_btn"]', { timeout: TIMEOUT });


### PR DESCRIPTION
This pull request adds a sleep operation to make the test's behavior more stable.

While running the test, I noticed puppeteer fails to correctly type the email when the login page is not fully rendered yet. I'm not sure if 1 second is enough for all other cases, but it works at least for my environment.