### PR TITLE
BUGFIX: Fixed issue when trying to log in

### DIFF
--- a/starterfiles/test/functional/button.test.js
+++ b/starterfiles/test/functional/button.test.js
@@ -10,6 +10,7 @@ describe('Starter Test', () => {
       browser = await puppeteer.launch({
         headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        slowMo: 50
       });
       page = await browser.newPage();
     });

--- a/starterfiles/test/functional/modal.test.js
+++ b/starterfiles/test/functional/modal.test.js
@@ -10,6 +10,7 @@ describe('Starter Test', () => {
       browser = await puppeteer.launch({
         headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        slowMo: 50
       });
       page = await browser.newPage();
     });

--- a/starterfiles/test/functional/slash_command.test.js
+++ b/starterfiles/test/functional/slash_command.test.js
@@ -10,6 +10,7 @@ describe('Starter Test', () => {
       browser = await puppeteer.launch({
         headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        slowMo: 50
       });
       page = await browser.newPage();
     });

--- a/starterfiles/test/functional/starter.test.js
+++ b/starterfiles/test/functional/starter.test.js
@@ -10,6 +10,7 @@ describe('Starter Test', () => {
       browser = await puppeteer.launch({
         headless: false,
         args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        slowMo: 50
       });
       page = await browser.newPage();
     })


### PR DESCRIPTION
There is an issue where it would start to enter the email before the page completely finishes loading. Once it finishes loading, it cuts off the email and enters the password. Adding `slowMo: 50` seems to fix this issue, so adding it to all of the tests.