### PR TITLE
fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ This repo is used for the Spec 2019 workshop `Functional Testing Slack Bots`.
 
 This repo contains both the source code for the Slack Bot we are writing tests against, as well as the test starter files.
 
-If you are attending the workshop and/or wanting to play with the tests and complete them, all you need is to follow the [README for the starterfiles]((starterfiles/README.md)).
+If you are attending the workshop and/or wanting to play with the tests and complete them, all you need is to follow the [README for the starterfiles](starterfiles/README.md).
 
-If you want to see the source code for the bot the tests are written for, you can checkout the [README here]((bot/README.md)).
+If you want to see the source code for the bot the tests are written for, you can checkout the [README here](bot/README.md).


### PR DESCRIPTION
links went to (\<folder>/README.md), should just go to \<folder>/READM.md

![broken-links](https://user-images.githubusercontent.com/1487463/67421181-ddf7bf00-f584-11e9-8255-9391bb66bfbd.gif)
